### PR TITLE
build: Remove --dev option from Hashicorp Vault

### DIFF
--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -40,6 +40,5 @@ COPY src .
 
 ENV PYTHONPATH "${PYTHONPATH}:src"
 
-# Run the application.
-CMD python secret_santa_bot/main.py
-
+# Read in VAULT_TOKEN set by hashicorp vault
+CMD sh /build/workflow_bot.sh

--- a/dev/docker/compose.yaml
+++ b/dev/docker/compose.yaml
@@ -5,28 +5,34 @@ services:
       dockerfile: ./dev/docker/Dockerfile
     volumes:
       - ../../src:/app
+      - runtime_secrets:/runtime_secrets
+      - ./workflow_bot.sh:/build/workflow_bot.sh
+    depends_on:
+      - vault
     environment:
       VAULT_PATH: 'http://vault:8200'
-      VAULT_TOKEN: 'my_root'
     networks:
       - santas_workshop
-  secrets:
+  vault:
     image: hashicorp/vault
     container_name: vault
     volumes:
-      - ./secrets:/secrets
+      - runtime_secrets:/runtime_secrets
+      - ./config.hcl:/vault_config/config.hcl
+      - ./workflow_vault.sh:/workflow_vault.sh
     environment:
-      VAULT_DEV_ROOT_TOKEN_ID: 'my_root'
+      VAULT_CONFIG: '/vault_config/config.hcl'
+      VAULT_ADDR: 'http://127.0.0.1:8200'
     cap_add:
       - IPC_LOCK
-    command: ["server", "--dev"]
+    command: ["ash", "./workflow_vault.sh"]
     ports:
       - "127.0.0.1:8200:8200"
     networks:
       - santas_workshop
 
+volumes:
+  runtime_secrets:
+
 networks:
   santas_workshop:
-
-volumes:
-  secrets:

--- a/dev/docker/config.hcl
+++ b/dev/docker/config.hcl
@@ -1,0 +1,11 @@
+storage "file" {
+  path    = "./vault/data"
+}
+
+listener "tcp" {
+  address     = "0.0.0.0:8200"
+  tls_disable = "true"
+}
+
+api_addr = "https://127.0.0.1:8200"
+cluster_addr = "https://127.0.0.1:8201"

--- a/dev/docker/workflow_bot.sh
+++ b/dev/docker/workflow_bot.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env ash
+
+VAULT_TOKEN="$(cat /runtime_secrets/root_token.txt)" && \
+export VAULT_TOKEN && \
+python secret_santa_bot/main.py

--- a/dev/docker/workflow_vault.sh
+++ b/dev/docker/workflow_vault.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env ash
+
+# Start vault
+vault server -config "$VAULT_CONFIG" &
+sleep 3
+[ ! -e generated_keys.txt ] && vault operator init > generated_keys.txt
+
+sleep 3
+# Parse unsealed keys
+keys="$(awk -F': ' '/Unseal Key [0-9]+:/ {print $2}' generated_keys.txt)"
+for key in $keys; do
+    vault operator unseal "$key"
+done
+
+# Get root token
+rootToken="$(awk -F': ' '/Initial Root Token:/ {print $2}' generated_keys.txt)"
+[ ! -e /secrets/root_token.txt ] && echo "$rootToken" > /runtime_secrets/root_token.txt
+
+# Enable kv secrets
+vault login "$rootToken"
+vault secrets enable -path=secret kv
+
+wait


### PR DESCRIPTION
## What?
Swap Hashicorp Vault off of dev mode
## Why?
Switching off dev mode allows persistent memory allowing developers to avoid inputting environment variables every time the dev environment is restarted.
## How?
Update compose.yaml to initialise Hashicorp Vault and unlock the vault to generate a root token. Root token is then used in the SantaBot program through a shared volume.
## Testing?
Images build from scratch and successfully launch into the main loop of the SantaBot.
## Screenshots (optional)
n/a
## Anything Else?
The implementation should NOT be used for any production environment. This is not a secure way for the secrets to be communicated.