### PR TITLE
fix(): Docker compose line end issue

### DIFF
--- a/dev/docker/compose.yaml
+++ b/dev/docker/compose.yaml
@@ -11,6 +11,7 @@ services:
       - vault
     environment:
       VAULT_PATH: 'http://vault:8200'
+      ROOT_TOKEN_FILE: '/runtime_secrets/root_token.txt'
     networks:
       - santas_workshop
   vault:
@@ -23,6 +24,7 @@ services:
     environment:
       VAULT_CONFIG: '/vault_config/config.hcl'
       VAULT_ADDR: 'http://127.0.0.1:8200'
+      ROOT_TOKEN_FILE: '/runtime_secrets/root_token.txt'
     cap_add:
       - IPC_LOCK
     command: ["ash", "./workflow_vault.sh"]

--- a/dev/docker/workflow_bot.sh
+++ b/dev/docker/workflow_bot.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env ash
 
-VAULT_TOKEN="$(cat /runtime_secrets/root_token.txt)" && \
+VAULT_TOKEN="$(cat "$ROOT_TOKEN_FILE")" && \
 export VAULT_TOKEN && \
-python secret_santa_bot/main.py
+python "secret_santa_bot/main.py"

--- a/dev/docker/workflow_vault.sh
+++ b/dev/docker/workflow_vault.sh
@@ -14,7 +14,7 @@ done
 
 # Get root token
 rootToken="$(awk -F': ' '/Initial Root Token:/ {print $2}' generated_keys.txt)"
-[ ! -e /secrets/root_token.txt ] && echo "$rootToken" > /runtime_secrets/root_token.txt
+[ ! -e /secrets/root_token.txt ] && echo "$rootToken" > "$ROOT_TOKEN_FILE"
 
 # Enable kv secrets
 vault login "$rootToken"


### PR DESCRIPTION
## What?
Fix workflow_vault.sh EOL issue.
Replace file reference with enviornmental variable.
## Why?
Docker container failing to build.
Allow dockerfile to be more resilient to file name changes.
## How?
Fix newline symbol.
Add enviornmental variable reference for ROOT_TOKEN in Dockerfile.
## Testing?
Builds on clean install for Linux and Windows; docker build --no-cache --pull
## Screenshots (optional)
n/a
## Anything Else?
n/a